### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ The following task will watch source files and rebuild the site for you:
 
     make watch
 
-note: A bug with metalsmith-collections currently whereby the Metalsmith object metadata is not correctly purged, may result in duplicate collections rendering while watched.
-
 ## Author
 
 Draft documents with the YAML frontmatter `draft` key set to `true` will not be rendered when the site is built, e.g.


### PR DESCRIPTION
The bug[1] is only apparent when building via metalsmith watch, which the author suggests isn't the right way to go about things. We now build with gulp, and the bug no longer manifests.

[1] https://github.com/segmentio/metalsmith-collections/issues/27