### PR TITLE
Fix deb pkg name and snappy cli binary name.

### DIFF
--- a/src/content/guides/ubuntu-classic.md
+++ b/src/content/guides/ubuntu-classic.md
@@ -95,11 +95,11 @@ Run `snapcraft` again to pick up this change. You can now install and run your s
 To see how your app will behave once downloaded from the Ubuntu Store, you’ll need to install some additional software. Open a terminal and run the following commands:
 
     $ sudo apt-get install snapd
-    $ sudo snappy install ubuntu-core
+    $ sudo snap install ubuntu-core
 
 You will now be able to install the snap file you created earlier:
 
-    $ sudo snappy install *.snap
+    $ sudo snap install *.snap
 
 At the time of writing, integration with the graphical application launcher has not been implemented. Instead, you can start your app from the terminal, replacing your_app_name with the value you chose in the snapcraft.yaml file above:
 

--- a/src/content/guides/ubuntu-classic.md
+++ b/src/content/guides/ubuntu-classic.md
@@ -94,7 +94,7 @@ Run `snapcraft` again to pick up this change. You can now install and run your s
 # Testing it out
 To see how your app will behave once downloaded from the Ubuntu Store, you’ll need to install some additional software. Open a terminal and run the following commands:
 
-    $ sudo apt-get install ubuntu-snappy
+    $ sudo apt-get install snapd
     $ sudo snappy install ubuntu-core
 
 You will now be able to install the snap file you created earlier:


### PR DESCRIPTION
According to `apt show ubuntu-snappy`, it's "a transitional dummy package" and "can safely be removed". AFAIK, the correct deb pkg is called snapd now.

Also, the snappy CLI binary is called snap (not snappy).